### PR TITLE
Linux compatibility + GitHub Action for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+
+      - name: Setup bats
+        run: git clone https://github.com/sstephenson/bats.git
+
+      - name: Test
+        run: CACHE_DIR="$GITHUB_WORKSPACE/" ./bats/bin/bats test

--- a/cache
+++ b/cache
@@ -62,7 +62,12 @@ fresh () {
 
 	# if a ttl is specified, we need to check the last modified
 	# timestamp on the $cache_file
-	mtime=$(stat -f %m $cache_file)
+	if [[ "$OSTYPE" == "darwin"* ]]; then
+		mtime=$(stat -f %m $cache_file)
+	else
+		mtime=$(stat -c %Y $cache_file)
+	fi
+
 	now=$(date +%s)
 	remaining_time=$(($now - $mtime))
 

--- a/test/cache.bats
+++ b/test/cache.bats
@@ -1,20 +1,21 @@
 setup() {
   export TEST_KEY="cache-tests-key"
+  export CACHE_DIR=${CACHE_DIR:-$TMPDIR}
 
   # clean up any old cache file (-f because we don't care if it exists or not)
-  rm -f "$TMPDIR$TEST_KEY"
+  rm -f "$CACHE_DIR$TEST_KEY"
 }
 
 @test "initial run is uncached" {
   run ./cache $TEST_KEY echo hello
   [ "$status" -eq 0 ]
-  [ $output = "hello" ]
+  [ "$output" = "hello" ]
 }
 
 @test "works for quoted arguments" {
   run ./cache $TEST_KEY printf "%s - %s\n" flounder fish
   [ "$status" -eq 0 ]
-  [ $output = "flounder - fish" ]
+  [ "$output" = "flounder - fish" ]
 }
 
 @test "preserves the status code of the original command" {
@@ -25,59 +26,59 @@ setup() {
 @test "subsequent runs are cached" {
   run ./cache $TEST_KEY echo initial-value
   [ "$status" -eq 0 ]
-  [ $output = "initial-value" ]
+  [ "$output" = "initial-value" ]
 
   run ./cache $TEST_KEY echo new-value
   [ "$status" -eq 0 ]
-  [ $output = "initial-value" ]
+  [ "$output" = "initial-value" ]
 }
 
 @test "respects a TTL" {
   run ./cache --ttl 1 $TEST_KEY echo initial-value
   [ "$status" -eq 0 ]
-  [ $output = "initial-value" ]
+  [ "$output" = "initial-value" ]
 
   run ./cache --ttl 1 $TEST_KEY echo new-value
   [ "$status" -eq 0 ]
-  [ $output = "initial-value" ]
+  [ "$output" = "initial-value" ]
 
   sleep 1
 
   run ./cache --ttl 1 $TEST_KEY echo third-value
   [ "$status" -eq 0 ]
-  [ $output = "third-value" ]
+  [ "$output" = "third-value" ]
 }
 
 @test "only caches 0 exit status by default" {
   run ./cache $TEST_KEY exit 1
   [ "$status" -eq 1 ]
-  [ ! -f "$TMPDIR$TEST_KEY" ]
+  [ ! -f "$CACHE_DIR$TEST_KEY" ]
 
   run ./cache $TEST_KEY exit 0
   [ "$status" -eq 0 ]
-  [ -f "$TMPDIR$TEST_KEY" ]
+  [ -f "$CACHE_DIR$TEST_KEY" ]
 }
 
 @test "allows specifying exit statuses to cache" {
   run ./cache --cache-status "1 2" $TEST_KEY exit 0
   [ "$status" -eq 0 ]
-  [ ! -f "$TMPDIR$TEST_KEY" ]
+  [ ! -f "$CACHE_DIR$TEST_KEY" ]
 
   run ./cache --cache-status "1 2" $TEST_KEY exit 1
   [ "$status" -eq 1 ]
-  [ -f "$TMPDIR$TEST_KEY" ]
+  [ -f "$CACHE_DIR$TEST_KEY" ]
 
-  rm "$TMPDIR$TEST_KEY"
+  rm "$CACHE_DIR$TEST_KEY"
 
   run ./cache --cache-status "1 2" $TEST_KEY exit 2
   [ "$status" -eq 2 ]
-  [ -f "$TMPDIR$TEST_KEY" ]
+  [ -f "$CACHE_DIR$TEST_KEY" ]
 }
 
 @test "allows specifying * to allow caching all statuses" {
   run ./cache --cache-status "*" $TEST_KEY exit 3
   [ "$status" -eq 3 ]
-  [ -f "$TMPDIR$TEST_KEY" ]
+  [ -f "$CACHE_DIR$TEST_KEY" ]
 }
 
 @test "returns the cached exit status" {
@@ -98,33 +99,39 @@ setup() {
 
 @test "stops parsing arguments after --" {
   run ./cache --ttl 1 -- $TEST_KEY grep --help
-  [ "$status" -eq 2 ]
-  echo $output | grep -- "usage: grep"
+
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+	[ "$status" -eq 2 ]
+	echo $output | grep -- "usage: grep"
+  else
+	[ "$status" -eq 0 ]
+	echo $output | grep -- "Usage: grep"
+  fi
 }
 
 @test "parses options before and after the cache key" {
   # fails because the status isn't allowed by our options
   run ./cache --cache-status "2" $TEST_KEY exit 0
   [ "$status" -eq 0 ]
-  [ ! -f "$TMPDIR$TEST_KEY" ]
+  [ ! -f "$CACHE_DIR$TEST_KEY" ]
 
   # succeeds because the status is allowed by our option before the
   # cache key
   run ./cache --cache-status "0 2" $TEST_KEY exit 2
   [ "$status" -eq 2 ]
-  [ -f "$TMPDIR$TEST_KEY" ]
+  [ -f "$CACHE_DIR$TEST_KEY" ]
 
-  rm "$TMPDIR$TEST_KEY"
+  rm "$CACHE_DIR$TEST_KEY"
 
   # succeeds because the status is allowed by our option after the
   # cache key
   run ./cache $TEST_KEY --cache-status "0 2" exit 2
   [ "$status" -eq 2 ]
-  [ -f "$TMPDIR$TEST_KEY" ]
+  [ -f "$CACHE_DIR$TEST_KEY" ]
 }
 
 @test "stops parsing options after the command starts" {
   run ./cache $TEST_KEY echo --ttl 1 --help
   [ "$status" -eq 0 ]
-  [ $output = "--ttl 1 --help" ]
+  [ "$output" = "--ttl 1 --help" ]
 }


### PR DESCRIPTION
NB: Quoting `$output` avoids `[: too many arguments` errors due to whitespace in the `$output` variable.